### PR TITLE
feat: Allow User Based Bench Folder Name Instead of Defaulting to "frappe-bench"

### DIFF
--- a/erpnext_install.sh
+++ b/erpnext_install.sh
@@ -140,10 +140,10 @@ check_existing_installations() {
     local installation_paths=()
     
     local search_paths=(
-        "$HOME/frappe-bench"
-        "/home/*/frappe-bench"
-        "/opt/frappe-bench"
-        "/var/www/frappe-bench"
+        "$HOME/$bench_name"
+        "/home/*/$bench_name"
+        "/opt/$bench_name"
+        "/var/www/$bench_name"
     )
     
     echo -e "${YELLOW}Checking for existing ERPNext installations...${NC}"
@@ -567,9 +567,11 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 nvm use default
 
-echo -e "${YELLOW}Initialising bench in frappe-bench folder.${NC}"
+echo -e "${YELLOW}Initialising bench in $bench_name folder.${NC}"
 echo -e "${LIGHT_BLUE}If you get a restart failed, don't worry, we will resolve that later.${NC}"
-bench init frappe-bench --version "$bench_version" --verbose
+read -p "Enter a name for your bench folder (default: frappe-bench): " bench_name
+bench_name=${bench_name:-frappe-bench}
+bench init "$bench_name" --version "$bench_version" --verbose
 echo -e "${GREEN}Bench installation complete!${NC}"
 sleep 1
 
@@ -585,7 +587,7 @@ sleep 2
 echo -e "${YELLOW}Now setting up your site. This might take a few minutes. Please wait...${NC}"
 sleep 1
 
-cd frappe-bench && \
+cd "$bench_name" && \
 sudo chmod -R o+rx "$(echo $HOME)"
 
 bench new-site "$site_name" \


### PR DESCRIPTION
### Reason of Pull Request
- Right now, the script always uses the folder name `frappe-bench`
- This PR lets the user type their own folder name when creating a new bench.
- If they don’t type anything, it still uses frappe-bench as default. 
- This is helpful for people who want to make more than one bench folder.
### Working Screenshots

<img width="835" height="207" alt="image" src="https://github.com/user-attachments/assets/e04e35a7-1084-4807-974e-a9198fcba8bb" />

<img width="1038" height="199" alt="image" src="https://github.com/user-attachments/assets/f7d093d0-b2d9-4d01-83d4-e984503e10d0" />

