### PR TITLE
fix: skip compiling Python from source if required version is already installed

### DIFF
--- a/erpnext_install.sh
+++ b/erpnext_install.sh
@@ -456,7 +456,7 @@ if [[ "$bench_version" == "version-16" ]]; then
     required_python_full="3.14.0"
 fi
 
-if [[ -z "$py_version" ]] || [[ "$py_major" -lt 3 ]] || [[ "$py_major" -eq 3 && "$py_minor" -lt "$required_python_minor" ]]; then
+if ( [[ -z "$py_version" ]] || [[ "$py_major" -lt 3 ]] || [[ "$py_major" -eq 3 && "$py_minor" -lt "$required_python_minor" ]] ) && ! command -v python3."${required_python_minor}" &> /dev/null; then
     echo -e "${LIGHT_BLUE}It appears this instance does not meet the minimum Python version required for ERPNext ${version_choice} (Python${required_python_label})...${NC}"
     sleep 2 
     echo -e "${YELLOW}Not to worry, we will sort it out for you${NC}"
@@ -477,6 +477,9 @@ if [[ -z "$py_version" ]] || [[ "$py_major" -lt 3 ]] || [[ "$py_major" -eq 3 && 
     sudo rm Python-${required_python_full}.tgz && \
     pip3."${required_python_minor}" install --user --upgrade pip && \
     echo -e "${GREEN}Python${required_python_label} installation successful!${NC}"
+    sleep 2
+elif command -v python3."${required_python_minor}" &> /dev/null; then
+    echo -e "${GREEN}Python ${required_python_label} is already installed. Skipping compilation.${NC}"
     sleep 2
 fi
 


### PR DESCRIPTION
Problem: When the installation script runs on a system with an older default Python version, it downloads and compiles the required Python version (e.g., 3.14) from source.

However, because the compilation uses altinstall (to avoid breaking system dependencies), the default python3 command remains unchanged. When the script is restarted or retried after a failure, it only checks python3 --version. As a result, it fails to recognize that the required version is already compiled and starts the entire slow compilation process from source all over again.

Solution: Modified the Python installation check in erpnext_install.sh to check if the target command is already available in the system path before initiating compilation.
